### PR TITLE
Fix 'standard' code issues

### DIFF
--- a/template/app/Ws/socket.js
+++ b/template/app/Ws/socket.js
@@ -14,4 +14,4 @@
 | Ws.channel('/chat', 'ChatController')
 */
 
-const Ws = use('Ws')
+// const Ws = use('Ws')

--- a/template/config/nuxt.js
+++ b/template/config/nuxt.js
@@ -19,7 +19,7 @@ module.exports = {
       {
         hid: 'description',
         name: 'description',
-        content: "Adonuxt project"
+        content: 'Adonuxt project'
       }
     ],
     link: [


### PR DESCRIPTION
When you run `npm run lint` (or `npm run precommit`), `standard` finds two code issues. This PR fixes them, so developers don't have to fix them manually.