### PR TITLE
Update "adonis-websocket"

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "adonis-framework": "^3.0.9",
     "adonis-lucid": "^3.0.13",
     "adonis-middleware": "^1.0.10",
-    "adonis-websocket": "^1.0.2",
+    "adonis-websocket": "^1.0.4",
     "cross-env": "^3.1.4",
     "nuxt": "latest",
     "standard": "^8.6.0",


### PR DESCRIPTION
Update to 1.0.4 required to solve the issue with deleted uWebSocket npm packages: https://github.com/adonisjs/adonis-websocket/issues/10